### PR TITLE
Replace newline with space for readLines abstract

### DIFF
--- a/inst/rmarkdown/templates/reed_thesis/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/reed_thesis/skeleton/skeleton.Rmd
@@ -8,7 +8,7 @@ altadvisor: 'Your Other Advisor'
 department: 'Mathematics'
 title: 'My Final College Paper'
 abstract: >
-  `r paste(readLines('abstract.Rmd'), collapse = '\n')`
+  `r paste(readLines('abstract.Rmd'), collapse = ' ')`
 # If you'd rather include the preliminary content in files instead of inline
 # like below, use a command like that for the abstract above.  Note that a tab is 
 # needed on the line after the >.


### PR DESCRIPTION
When I tried adding multiline Rmd files for abstract, preface, and other pages, I ended up getting the following error:

```
Could not parse YAML header: could not find expected ':' "source"
```

I realized this was because the `pasteLines` function was adding newlines in the YAML header, which ended up breaking the YAML indentation format. So instead, I propose here to use a space (`' '`) instead of a newline character (`\n`). This is less readable in the markdown, but at least it compiles 👌 
